### PR TITLE
✨ Replace item icons with EmojiOne PNGs

### DIFF
--- a/gitmoji.py
+++ b/gitmoji.py
@@ -7,32 +7,35 @@ from workflow import Workflow3, web
 
 gitmoji_db = 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
 emojione_assets = 'https://raw.githubusercontent.com/emojione/emojione-assets/master/png/128'
-esc_seqs = {'\\U000': ' ', '\\u': ' '}
 
 def get_gitmoji_db():
     return web.get(gitmoji_db).json()
 
+def determine_icon_name(emoji):
+    esc_seqs = ['\\U000', '\\u']
+    ascii_char = emoji.encode('unicode-escape')
+    codes = ascii_char
+    for x in esc_seqs:
+        codes = codes.replace(x, " ")
+    return codes.split()[0] + ".png"
+
+def fetch_icon(wf, emoji):
+    filename = determine_icon_name(emoji)
+    icon = wf.datafile(filename)
+    if not os.path.isfile(icon):
+        request = web.get(emojione_assets + '/' + filename)
+        request.save_to_path(icon)
+    return icon
 
 def main(wf):
     data = wf.cached_data('gitmoji_db', get_gitmoji_db, max_age=86400)
 
     for emoji in data['gitmojis']:
-        unicode_emoji = emoji['emoji']
-        ascii_emoji = unicode_emoji.encode('unicode-escape')
-        for r,s in esc_seqs.items():
-            ascii_emoji = ascii_emoji.replace(r,s)
-        codes = ascii_emoji.split()
-        filename = codes[0]
-        icon = wf.datafile(filename + '.png')
-        if not os.path.isfile(icon):
-            request = web.get(emojione_assets + '/' + filename + '.png')
-            request.save_to_path(icon)
-
         wf.add_item(
             title=emoji['emoji'] + ' ' + emoji['code'],
             subtitle=emoji['description'],
             valid=True,
-            icon=icon,
+            icon=fetch_icon(wf, emoji['emoji']),
             match=emoji['name'] + ' ' + emoji['description'],
             arg=emoji['code'],
             copytext=emoji['code'],

--- a/gitmoji.py
+++ b/gitmoji.py
@@ -7,6 +7,7 @@ from workflow import Workflow3, web
 
 gitmoji_db = 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
 emojione_assets = 'https://raw.githubusercontent.com/emojione/emojione-assets/master/png/128'
+esc_seqs = {'\\U000': ' ', '\\u': ' '}
 
 def get_gitmoji_db():
     return web.get(gitmoji_db).json()
@@ -16,15 +17,15 @@ def main(wf):
     data = wf.cached_data('gitmoji_db', get_gitmoji_db, max_age=86400)
 
     for emoji in data['gitmojis']:
-        unicode = emoji['emoji']
-        str = unicode.encode('unicode-escape')
-        if str.startswith('\U000'):
-            id  = str[5:]
-        elif str.startswith('\u'):
-            id = str.split('\u')[1]
-        icon = wf.datafile(id + '.png')
+        unicode_emoji = emoji['emoji']
+        ascii_emoji = unicode_emoji.encode('unicode-escape')
+        for r,s in esc_seqs.items():
+            ascii_emoji = ascii_emoji.replace(r,s)
+        codes = ascii_emoji.split()
+        filename = codes[0]
+        icon = wf.datafile(filename + '.png')
         if not os.path.isfile(icon):
-            request = web.get(emojione_assets + '/' + id + '.png')
+            request = web.get(emojione_assets + '/' + filename + '.png')
             request.save_to_path(icon)
 
         wf.add_item(

--- a/gitmoji.py
+++ b/gitmoji.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 # encoding: utf-8
 
-import sys
+import sys, os
 
 from workflow import Workflow3, web
 
 gitmoji_db = 'https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json'
-
+emojione_assets = 'https://raw.githubusercontent.com/emojione/emojione-assets/master/png/128'
 
 def get_gitmoji_db():
     return web.get(gitmoji_db).json()
@@ -16,11 +16,22 @@ def main(wf):
     data = wf.cached_data('gitmoji_db', get_gitmoji_db, max_age=86400)
 
     for emoji in data['gitmojis']:
+        unicode = emoji['emoji']
+        str = unicode.encode('unicode-escape')
+        if str.startswith('\U000'):
+            id  = str[5:]
+        elif str.startswith('\u'):
+            id = str.split('\u')[1]
+        icon = wf.datafile(id + '.png')
+        if not os.path.isfile(icon):
+            request = web.get(emojione_assets + '/' + id + '.png')
+            request.save_to_path(icon)
+
         wf.add_item(
             title=emoji['emoji'] + ' ' + emoji['code'],
             subtitle=emoji['description'],
             valid=True,
-            icon='9B7FE8AC-6582-4825-917E-92D0E0291CC1.png',
+            icon=icon,
             match=emoji['name'] + ' ' + emoji['description'],
             arg=emoji['code'],
             copytext=emoji['code'],

--- a/info.plist
+++ b/info.plist
@@ -70,7 +70,7 @@
 				<key>queuemode</key>
 				<integer>1</integer>
 				<key>runningsubtext</key>
-				<string></string>
+				<string>getting icons...</string>
 				<key>script</key>
 				<string>chmod +x jq &amp;&amp; cat gitmojis.json | ./jq --raw-output '{items: [.gitmojis | .[] | {emoji: .emoji, code: .code, title: (.emoji + " " + .code), subtitle: .description, match: (.description + " " + .name), arg: .code, text: {copy: .code, largetype: .code}}]}'</string>
 				<key>scriptargtype</key>


### PR DESCRIPTION
This resolves #2, by replacing the generic icon used for every workflow item with a PNG version of each item's specific emoji.

The image filenames are derived from the emoji's ASCII code, and then downloaded from the [EmojiOne Assets](https://github.com/emojione/emojione-assets) repository. Each file will be downloaded a single time when the workflow first opens, and then saved to the workflow's data directory (i.e. `/Users/{name}/Library/Application Support/Alfred 3/Workflow Data/org.leolabs.alfred.gitmoji`). The local files will continue to be reused as long as they exist there.

Thanks!